### PR TITLE
Fixed typo error in the Managed Configuration details

### DIFF
--- a/ZebraPrintService/build.gradle
+++ b/ZebraPrintService/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.zebra.zebraprintservice"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 26
-        versionName "1.1.4"
+        versionCode 27
+        versionName "1.1.5"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14"

--- a/ZebraPrintService/src/main/res/values/strings.xml
+++ b/ZebraPrintService/src/main/res/values/strings.xml
@@ -117,8 +117,8 @@
     <string name="printer_label_width_description">The width of the paper</string>
     <string name="printer_label_width_default_value">3.15</string>
 
-    <string name="printer_label_height_title">Paper Width</string>
-    <string name="printer_label_height_description">The width of the paper</string>
+    <string name="printer_label_height_title">Paper Height</string>
+    <string name="printer_label_height_description">The height of the paper</string>
     <string name="printer_label_height_default_value">10</string>
 
 </resources>


### PR DESCRIPTION
Fixed a typo error in the managed configuration declaration where the details of the Page Height was displaying "Page Width" instead of "Page Height".