### PR TITLE
Removing reserved characters from temp file name

### DIFF
--- a/ZebraPrintService/build.gradle
+++ b/ZebraPrintService/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.zebra.zebraprintservice"
         minSdkVersion 24
         targetSdkVersion 32
-        versionCode 27
-        versionName "1.1.5"
+        versionCode 28
+        versionName "1.1.6"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14"
@@ -18,9 +18,6 @@ android {
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
     }
-
-    //TODO: Added by Laurent Trudu because building a signed release apk doesn't work when the debug build has no pb. Need to understand why the Release build does not pass the lint stage.
-
 
     buildTypes {
         release {
@@ -39,6 +36,7 @@ android {
             version "3.10.2"
         }
     }
+    //TODO: Added by Laurent Trudu because building a signed release apk doesn't work when the debug build has no pb. Need to understand why the Release build does not pass the lint stage.
     lint {
         abortOnError false
         checkReleaseBuilds false

--- a/ZebraPrintService/build.gradle
+++ b/ZebraPrintService/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
     ndkVersion "21.0.6113669"
-    buildToolsVersion "29.0.2"
     defaultConfig {
-        applicationId "com.zebra.zebraprintservice.lt"
+        applicationId "com.zebra.zebraprintservice"
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 27
         versionName "1.1.5"
         externalNativeBuild {
@@ -21,12 +20,6 @@ android {
     }
 
     //TODO: Added by Laurent Trudu because building a signed release apk doesn't work when the debug build has no pb. Need to understand why the Release build does not pass the lint stage.
-    lintOptions {
-        checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
-        abortOnError false
-    }
 
 
     buildTypes {
@@ -45,6 +38,10 @@ android {
             path "src/main/cpp/CMakeLists.txt"
             version "3.10.2"
         }
+    }
+    lint {
+        abortOnError false
+        checkReleaseBuilds false
     }
 }
 

--- a/ZebraPrintService/build.gradle
+++ b/ZebraPrintService/build.gradle
@@ -5,7 +5,7 @@ android {
     ndkVersion "21.0.6113669"
     buildToolsVersion "29.0.2"
     defaultConfig {
-        applicationId "com.zebra.zebraprintservice"
+        applicationId "com.zebra.zebraprintservice.lt"
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 27

--- a/ZebraPrintService/build.gradle
+++ b/ZebraPrintService/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.zebra.zebraprintservice"
         minSdkVersion 24
         targetSdkVersion 32
-        versionCode 28
-        versionName "1.1.6"
+        versionCode 29
+        versionName "1.1.7"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14"

--- a/ZebraPrintService/src/main/AndroidManifest.xml
+++ b/ZebraPrintService/src/main/AndroidManifest.xml
@@ -2,11 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.zebra.zebraprintservice">
 
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/ZebraPrintService/src/main/AndroidManifest.xml
+++ b/ZebraPrintService/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
             android:name=".activities.PdfPrintActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/print"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -53,7 +54,8 @@
             android:name=".activities.ImagePrintActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/print"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/managedconfiguration/ManagedConfigurationHelper.java
+++ b/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/managedconfiguration/ManagedConfigurationHelper.java
@@ -157,7 +157,7 @@ public class ManagedConfigurationHelper {
             if(states.size() > 0)
             {
                 Log.d(TAG, "Sending state to feedback channel");
-                reporter.setStates(states, new KeyedAppStatesCallback() {
+                reporter.setStatesImmediate(states, new KeyedAppStatesCallback() {
                     @Override
                     public void onResult(int state, @Nullable Throwable throwable) {
                         Log.d(TAG, "reporter.setStates result: " + state);

--- a/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraDiscoverySession.java
+++ b/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraDiscoverySession.java
@@ -61,7 +61,7 @@ public class ZebraDiscoverySession extends PrinterDiscoverySession
             {
                 Intent i = new Intent(mService,PrinterInfoActivity.class);
                 i.putExtra("printer", Parcels.wrap(printer));
-                PendingIntent pi = PendingIntent.getActivity(mService,iReqCode,i,PendingIntent.FLAG_CANCEL_CURRENT);
+                PendingIntent pi = PendingIntent.getActivity(mService,iReqCode,i,PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
                 if (DEBUG) Log.i(TAG,"Adding Printer:" + printerId.getLocalId());
                 PrinterInfo.Builder builder = new PrinterInfo.Builder(printerId, printer.mName,print.isAvailable() ? PrinterInfo.STATUS_IDLE : PrinterInfo.STATUS_UNAVAILABLE)
                         .setIconResourceId(R.drawable.ic_printer)

--- a/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrintService.java
+++ b/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrintService.java
@@ -84,8 +84,8 @@ public class ZebraPrintService extends PrintService
     protected void onDisconnected()
     {
         if (DEBUG) Log.d(TAG, "onDisconnected()");
-        super.onDisconnected();
         unregisterManagedConfigurationChangeBroadcastReceiver();
+        super.onDisconnected();
     }
 
     /**********************************************************************************************/
@@ -154,6 +154,17 @@ public class ZebraPrintService extends PrintService
 
     private void unregisterManagedConfigurationChangeBroadcastReceiver()
     {
-        unregisterReceiver(app_restrictions_changed_broadcastReceiver);
+        try
+        {
+            unregisterReceiver(app_restrictions_changed_broadcastReceiver);
+        }
+        catch(Exception e)
+        {
+            if(DEBUG)
+            {
+                Log.e(TAG, "Error in unregisterManagedConfigurationChangeBroadcastReceiver");
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrinter.java
+++ b/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrinter.java
@@ -330,7 +330,7 @@ public class ZebraPrinter implements Handler.Callback
                     {
                         //Create a file copy of the document
                         ParcelFileDescriptor inParcel = doc.getData();
-                        mTempFile = File.createTempFile(doc.getInfo().getName(), null, mService.getCacheDir());
+                        mTempFile = File.createTempFile(doc.getInfo().getName().replaceAll("[\\\\/:*?\"<>|]", ""), null, mService.getCacheDir());
                         mTempFile.deleteOnExit();
 
                         InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(inParcel);

--- a/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrinter.java
+++ b/ZebraPrintService/src/main/java/com/zebra/zebraprintservice/service/ZebraPrinter.java
@@ -339,7 +339,7 @@ public class ZebraPrinter implements Handler.Callback
                     {
                         //Create a file copy of the document
                         ParcelFileDescriptor inParcel = doc.getData();
-                        mTempFile = File.createTempFile(doc.getInfo().getName(), null, mService.getCacheDir());
+                        mTempFile = File.createTempFile(doc.getInfo().getName().replaceAll("[\\\\/:*?\"<>|]", ""), null, mService.getCacheDir());
                         mTempFile.deleteOnExit();
 
                         InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(inParcel);

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
When printing from https: website, temp file name includes ":" and results in error during temp file creation. Fixed to remove reserved characters.